### PR TITLE
Add GitHub actions workflow for building IPA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,9 +57,7 @@ jobs:
 
             - name: Create IPA
               run: |
-                  cd Payload
-                  zip -r ../StosVPN-fakesigned.ipa Payload
-                  cd .. # Go back to the root directory
+                  zip -r ./StosVPN-fakesigned.ipa Payload
 
             - name: Upload IPA Artifact
               uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
               run: mkdir -p Payload
 
             - name: Copy App to Payload
-              run: cp -R build/StosVPN.xcarchive/Products/Applications/StosVPN.app Payload/
+              run: cp -R build/StosVPN.xcarchive/Products/Applications/StosVPN.app Payload/StosVPN.app
 
             - name: Find and Sign App Extension
               run: |
@@ -58,7 +58,7 @@ jobs:
             - name: Create IPA
               run: |
                   cd Payload
-                  zip -r ../StosVPN-fakesigned.ipa .
+                  zip -r ../StosVPN-fakesigned.ipa Payload
                   cd .. # Go back to the root directory
 
             - name: Upload IPA Artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,68 @@
+name: Build IPA with Fake Signing
+
+on:
+    push:
+        branches: [main] # Or your default branch
+    workflow_dispatch: # Allows manual triggering
+
+jobs:
+    build:
+        runs-on: macos-latest # Use the latest macOS runner
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Install ldid
+              run: brew install ldid
+
+            # - name: Select Xcode version (Optional - Adjust if needed)
+            #   run: sudo xcode-select -s /Applications/Xcode_$(xcodebuild -version | grep Xcode | cut -d' ' -f2).app
+
+            - name: Build Xcode Archive
+              run: |
+                  xcodebuild archive \
+                    -project StosVPN.xcodeproj \
+                    -scheme StosVPN \
+                    -destination 'generic/platform=iOS' \
+                    -archivePath build/StosVPN.xcarchive \
+                    CODE_SIGN_IDENTITY="" \
+                    CODE_SIGNING_REQUIRED=NO \
+                    CODE_SIGNING_ALLOWED=NO
+
+            - name: Create Payload directory
+              run: mkdir -p Payload
+
+            - name: Copy App to Payload
+              run: cp -R build/StosVPN.xcarchive/Products/Applications/StosVPN.app Payload/
+
+            - name: Find and Sign App Extension
+              run: |
+                  APPEX_PATH=$(find Payload/StosVPN.app/PlugIns -name "*.appex" | head -n 1)
+                  if [ -z "$APPEX_PATH" ]; then
+                    echo "Error: App Extension (.appex) not found in PlugIns directory."
+                    exit 1
+                  fi
+                  echo "Found App Extension at: $APPEX_PATH"
+                  # Use the specific entitlements for the extension
+                  ldid -S"${GITHUB_WORKSPACE}/TunnelProv/TunnelProv.entitlements" "$APPEX_PATH/$(basename "$APPEX_PATH" .appex)"
+                  echo "Signed App Extension."
+
+            - name: Sign Main App Bundle
+              run: |
+                  APP_BINARY_PATH="Payload/StosVPN.app/StosVPN"
+                  # Use the specific entitlements for the main app
+                  ldid -S"${GITHUB_WORKSPACE}/StosVPN/StosVPN.entitlements" "$APP_BINARY_PATH"
+                  echo "Signed Main App Bundle."
+
+            - name: Create IPA
+              run: |
+                  cd Payload
+                  zip -r ../StosVPN-fakesigned.ipa .
+                  cd .. # Go back to the root directory
+
+            - name: Upload IPA Artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: StosVPN-IPA.ipa
+                  path: StosVPN-fakesigned.ipa

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,8 @@ jobs:
             - name: Install ldid
               run: brew install ldid
 
-            # - name: Select Xcode version (Optional - Adjust if needed)
-            #   run: sudo xcode-select -s /Applications/Xcode_$(xcodebuild -version | grep Xcode | cut -d' ' -f2).app
+            - name: Select Xcode version
+              run: sudo xcode-select -s /Applications/Xcode_16.2.app
 
             - name: Build Xcode Archive
               run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.ipa
 /build
+
+**/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.ipa
+/build


### PR DESCRIPTION
In order for this to work when sideloaded through SideStore, you need a paid developer account. First, download and install the IPA using SideStore (make sure you keep app extensions), then go into the Apple Developer Portal > Identifiers and find both app IDs that have StosVPN in them. For each one, add the "Personal VPN" and "Network Extensions" entitlements. Then, delete StosVPN from your device and reinstall it. It should work from there.